### PR TITLE
fix: Property 'remove' does not exist on type 'Model<T, {}, ...>

### DIFF
--- a/utils/repository.ts
+++ b/utils/repository.ts
@@ -26,7 +26,7 @@ export class Repository<T extends Document> {
   }
 
   async remove(filter: FilterQuery<T>): Promise<RemovedModel> {
-    const { deletedCount } = await this.model.remove(filter);
+    const { deletedCount } = await this.model.deleteMany(filter);
     return { deletedCount, deleted: !!deletedCount };
   }
 


### PR DESCRIPTION
Hi. Thankyou for the repo, it's a great help for learning NestJS + Mongoose :)

I fixed an issue related to removing documents using Mongoose. `remove` can no longer be used, as explained in these threads here:

1. https://stackoverflow.com/questions/75689772/error-ts2339-property-remove-does-not-exist-on-type-documentunknown
2. https://stackoverflow.com/questions/5809788/how-do-i-remove-documents-using-node-js-mongoose

Based on the intent from entities, I figured out `deleteMany` would be suitable here, but `deleteOne` or `findByIdAndDelete` can also be used.